### PR TITLE
Update for NodeCG v2 typings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import NodeCG from '@alvancamp/test-nodecg-types';
-import '@alvancamp/test-nodecg-types/augment-window';
 import clone from 'clone';
 import { computed, DeepReadonly, isRef, reactive, readonly, ref, Ref, watch } from 'vue-demi';
 

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
-import { ref, watch, isRef, reactive, computed, readonly, Ref, DeepReadonly } from 'vue-demi'
-import { ReplicantOptions } from 'nodecg-types/types/browser'
-import clone from 'clone'
+import NodeCG from '@alvancamp/test-nodecg-types';
+import '@alvancamp/test-nodecg-types/augment-window';
+import clone from 'clone';
+import { computed, DeepReadonly, isRef, reactive, readonly, ref, Ref, watch } from 'vue-demi';
 
 interface ReactiveReplicant<T> {
     data: T | undefined,
@@ -11,11 +12,11 @@ interface ReactiveReplicant<T> {
     loadDefault: () => void
 }
 
-export function useReplicant<T>(name: string, namespace: string | undefined, opts: ReplicantOptions<T> = {}) {
+export function useReplicant<T>(name: string, namespace: string | undefined, opts: NodeCG.Replicant.Options<T> = {}) {
     return useReplicantRaw(name, namespace, opts)?.reactiveReplicant
 }
 
-function useReplicantRaw<T>(name: string, namespace: string | ReplicantOptions<T> | undefined, opts: ReplicantOptions<T> | undefined) {
+function useReplicantRaw<T>(name: string, namespace: string | NodeCG.Replicant.Options<T> | undefined, opts: NodeCG.Replicant.Options<T> | undefined) {
 	if (isRef(name)) {
 		console.warn(`Tried to create a StaticReplicant using a reactive name (${name.value})`)
 		return null
@@ -80,7 +81,7 @@ function useReplicantRaw<T>(name: string, namespace: string | ReplicantOptions<T
     }
 }
 
-export function useDynamicReplicant<T>(name: Ref<string>, namespace: string, opts: ReplicantOptions<T> | undefined) {
+export function useDynamicReplicant<T>(name: Ref<string>, namespace: string, opts: NodeCG.Replicant.Options<T> | undefined) {
 	if (!isRef(name)) {
 		console.warn(`Tried to create a DynamicReplicant using a static name (${name})`)
 		return null

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="@alvancamp/test-nodecg-types/augment-window" />
 import NodeCG from '@alvancamp/test-nodecg-types';
 import clone from 'clone';
 import { computed, DeepReadonly, isRef, reactive, readonly, ref, Ref, watch } from 'vue-demi';

--- a/index.ts
+++ b/index.ts
@@ -91,7 +91,7 @@ export function useDynamicReplicant<T>(name: Ref<string>, namespace: string, opt
 
     function setReplicant(oldName?: string) {
         // remove old listeners when we change the name to prevent potential memory leaks
-        if (oldName && repRef.value) nodecg.Replicant(oldName).removeListener('change', repRef.value.listener)
+        if (oldName && repRef.value) nodecg.Replicant<T>(oldName).removeListener('change', repRef.value.listener)
 
         if (!(typeof name.value === 'string' || typeof name.value === 'number')) {
             repRef.value = null

--- a/index.ts
+++ b/index.ts
@@ -29,8 +29,8 @@ function useReplicantRaw<T>(name: string, namespace: string | NodeCG.Replicant.O
     let rep = typeof namespace === 'string' ? nodecg.Replicant<T>(name, namespace, opts) : nodecg.Replicant<T>(name, opts)
 
     // TODO: work out why this assertion is necessary
-    const newVal = ref(clone(opts?.defaultValue)) as Ref<T | undefined>
-    const oldVal = ref(clone(opts?.defaultValue)) as Ref<T | undefined>
+    const newVal = ref(clone(opts && "defaultValue" in opts ? opts.defaultValue : undefined)) as Ref<T | undefined>
+    const oldVal = ref(clone(opts && "defaultValue" in opts ? opts.defaultValue : undefined)) as Ref<T | undefined>
     const changed = ref(false)
     const upToDate = ref(true)
 
@@ -63,7 +63,7 @@ function useReplicantRaw<T>(name: string, namespace: string | NodeCG.Replicant.O
         newVal.value = clone(oldVal.value)
     }
     function loadDefault() {
-        newVal.value = clone(opts?.defaultValue)
+        newVal.value = clone(opts && "defaultValue" in opts ? opts.defaultValue : undefined)
     }
 
     const reactiveReplicant: ReactiveReplicant<T> = reactive({

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/clone": "^2.1.1",
     "clone": "^2.1.2",
-    "vue-demi": "^0.12.1"
+    "vue-demi": "^0.13.11"
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.4.0",
@@ -28,8 +28,8 @@
     }
   },
   "devDependencies": {
-    "nodecg-types": "^1.8.3",
-    "typescript": "^4.5.5",
-    "vue": "^3.0.0"
+    "@alvancamp/test-nodecg-types": "^1.9.26",
+    "typescript": "^4.9.4",
+    "vue": "^3.2.45"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "devDependencies": {
-    "@alvancamp/test-nodecg-types": "^1.9.26",
+    "@alvancamp/test-nodecg-types": "^1.9.27",
     "typescript": "^4.9.4",
     "vue": "^3.2.45"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,168 +1,185 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
+  '@alvancamp/test-nodecg-types': ^1.9.26
   '@types/clone': ^2.1.1
   clone: ^2.1.2
-  nodecg-types: ^1.8.3
-  typescript: ^4.5.5
-  vue: ^3.0.0
-  vue-demi: ^0.12.1
+  typescript: ^4.9.4
+  vue: ^3.2.45
+  vue-demi: ^0.13.11
 
 dependencies:
-  '@types/clone': registry.npmjs.org/@types/clone/2.1.1
+  '@types/clone': 2.1.1
   clone: 2.1.2
-  vue-demi: 0.12.1_vue@3.2.29
+  vue-demi: 0.13.11_vue@3.2.45
 
 devDependencies:
-  nodecg-types: registry.npmjs.org/nodecg-types/1.8.3
-  typescript: registry.npmjs.org/typescript/4.5.5
-  vue: 3.2.29
+  '@alvancamp/test-nodecg-types': 1.9.26
+  typescript: 4.9.4
+  vue: 3.2.45
 
 packages:
 
-  /@babel/parser/7.16.12:
-    resolution: {integrity: sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==}
+  /@alvancamp/test-nodecg-types/1.9.26:
+    resolution: {integrity: sha512-4Y1DuNHwLphwukyldS5KoCGo/taxPTngJAiKwhVhi6a2bokCNNGZ/g/4BSvFa8FqjlpU9+OH2MSX/hxz3HQpOA==}
+    dev: true
+
+  /@babel/helper-string-parser/7.19.4:
+    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier/7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/parser/7.20.7:
+    resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dev: true
-
-  /@vue/compiler-core/3.2.29:
-    resolution: {integrity: sha512-RePZ/J4Ub3sb7atQw6V6Rez+/5LCRHGFlSetT3N4VMrejqJnNPXKUt5AVm/9F5MJriy2w/VudEIvgscCfCWqxw==}
     dependencies:
-      '@babel/parser': 7.16.12
-      '@vue/shared': 3.2.29
+      '@babel/types': 7.20.7
+
+  /@babel/types/7.20.7:
+    resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+
+  /@types/clone/2.1.1:
+    resolution: {integrity: sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg==}
+    dev: false
+
+  /@vue/compiler-core/3.2.45:
+    resolution: {integrity: sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==}
+    dependencies:
+      '@babel/parser': 7.20.7
+      '@vue/shared': 3.2.45
       estree-walker: 2.0.2
       source-map: 0.6.1
-    dev: true
 
-  /@vue/compiler-dom/3.2.29:
-    resolution: {integrity: sha512-y26vK5khdNS9L3ckvkqJk/78qXwWb75Ci8iYLb67AkJuIgyKhIOcR1E8RIt4mswlVCIeI9gQ+fmtdhaiTAtrBQ==}
+  /@vue/compiler-dom/3.2.45:
+    resolution: {integrity: sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==}
     dependencies:
-      '@vue/compiler-core': 3.2.29
-      '@vue/shared': 3.2.29
-    dev: true
+      '@vue/compiler-core': 3.2.45
+      '@vue/shared': 3.2.45
 
-  /@vue/compiler-sfc/3.2.29:
-    resolution: {integrity: sha512-X9+0dwsag2u6hSOP/XsMYqFti/edvYvxamgBgCcbSYuXx1xLZN+dS/GvQKM4AgGS4djqo0jQvWfIXdfZ2ET68g==}
+  /@vue/compiler-sfc/3.2.45:
+    resolution: {integrity: sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==}
     dependencies:
-      '@babel/parser': 7.16.12
-      '@vue/compiler-core': 3.2.29
-      '@vue/compiler-dom': 3.2.29
-      '@vue/compiler-ssr': 3.2.29
-      '@vue/reactivity-transform': 3.2.29
-      '@vue/shared': 3.2.29
+      '@babel/parser': 7.20.7
+      '@vue/compiler-core': 3.2.45
+      '@vue/compiler-dom': 3.2.45
+      '@vue/compiler-ssr': 3.2.45
+      '@vue/reactivity-transform': 3.2.45
+      '@vue/shared': 3.2.45
       estree-walker: 2.0.2
-      magic-string: 0.25.7
-      postcss: 8.4.6
+      magic-string: 0.25.9
+      postcss: 8.4.21
       source-map: 0.6.1
-    dev: true
 
-  /@vue/compiler-ssr/3.2.29:
-    resolution: {integrity: sha512-LrvQwXlx66uWsB9/VydaaqEpae9xtmlUkeSKF6aPDbzx8M1h7ukxaPjNCAXuFd3fUHblcri8k42lfimHfzMICA==}
+  /@vue/compiler-ssr/3.2.45:
+    resolution: {integrity: sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==}
     dependencies:
-      '@vue/compiler-dom': 3.2.29
-      '@vue/shared': 3.2.29
-    dev: true
+      '@vue/compiler-dom': 3.2.45
+      '@vue/shared': 3.2.45
 
-  /@vue/reactivity-transform/3.2.29:
-    resolution: {integrity: sha512-YF6HdOuhdOw6KyRm59+3rML8USb9o8mYM1q+SH0G41K3/q/G7uhPnHGKvspzceD7h9J3VR1waOQ93CUZj7J7OA==}
+  /@vue/reactivity-transform/3.2.45:
+    resolution: {integrity: sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==}
     dependencies:
-      '@babel/parser': 7.16.12
-      '@vue/compiler-core': 3.2.29
-      '@vue/shared': 3.2.29
+      '@babel/parser': 7.20.7
+      '@vue/compiler-core': 3.2.45
+      '@vue/shared': 3.2.45
       estree-walker: 2.0.2
-      magic-string: 0.25.7
-    dev: true
+      magic-string: 0.25.9
 
-  /@vue/reactivity/3.2.29:
-    resolution: {integrity: sha512-Ryhb6Gy62YolKXH1gv42pEqwx7zs3n8gacRVZICSgjQz8Qr8QeCcFygBKYfJm3o1SccR7U+bVBQDWZGOyG1k4g==}
+  /@vue/reactivity/3.2.45:
+    resolution: {integrity: sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==}
     dependencies:
-      '@vue/shared': 3.2.29
-    dev: true
+      '@vue/shared': 3.2.45
 
-  /@vue/runtime-core/3.2.29:
-    resolution: {integrity: sha512-VMvQuLdzoTGmCwIKTKVwKmIL0qcODIqe74JtK1pVr5lnaE0l25hopodmPag3RcnIcIXe+Ye3B2olRCn7fTCgig==}
+  /@vue/runtime-core/3.2.45:
+    resolution: {integrity: sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==}
     dependencies:
-      '@vue/reactivity': 3.2.29
-      '@vue/shared': 3.2.29
-    dev: true
+      '@vue/reactivity': 3.2.45
+      '@vue/shared': 3.2.45
 
-  /@vue/runtime-dom/3.2.29:
-    resolution: {integrity: sha512-YJgLQLwr+SQyORzTsBQLL5TT/5UiV83tEotqjL7F9aFDIQdFBTCwpkCFvX9jqwHoyi9sJqM9XtTrMcc8z/OjPA==}
+  /@vue/runtime-dom/3.2.45:
+    resolution: {integrity: sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==}
     dependencies:
-      '@vue/runtime-core': 3.2.29
-      '@vue/shared': 3.2.29
-      csstype: 2.6.19
-    dev: true
+      '@vue/runtime-core': 3.2.45
+      '@vue/shared': 3.2.45
+      csstype: 2.6.21
 
-  /@vue/server-renderer/3.2.29_vue@3.2.29:
-    resolution: {integrity: sha512-lpiYx7ciV7rWfJ0tPkoSOlLmwqBZ9FTmQm33S+T4g0j1fO/LmhJ9b9Ctl1o5xvIFVDk9QkSUWANZn7H2pXuxVw==}
+  /@vue/server-renderer/3.2.45_vue@3.2.45:
+    resolution: {integrity: sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==}
     peerDependencies:
-      vue: 3.2.29
+      vue: 3.2.45
     dependencies:
-      '@vue/compiler-ssr': 3.2.29
-      '@vue/shared': 3.2.29
-      vue: 3.2.29
-    dev: true
+      '@vue/compiler-ssr': 3.2.45
+      '@vue/shared': 3.2.45
+      vue: 3.2.45
 
-  /@vue/shared/3.2.29:
-    resolution: {integrity: sha512-BjNpU8OK6Z0LVzGUppEk0CMYm/hKDnZfYdjSmPOs0N+TR1cLKJAkDwW8ASZUvaaSLEi6d3hVM7jnWnX+6yWnHw==}
-    dev: true
+  /@vue/shared/3.2.45:
+    resolution: {integrity: sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==}
 
   /clone/2.1.2:
-    resolution: {integrity: sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=}
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
     dev: false
 
-  /csstype/2.6.19:
-    resolution: {integrity: sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==}
-    dev: true
+  /csstype/2.6.21:
+    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
-  /magic-string/0.25.7:
-    resolution: {integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==}
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: true
 
-  /nanoid/3.2.0:
-    resolution: {integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==}
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
-  /postcss/8.4.6:
-    resolution: {integrity: sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==}
+  /postcss/8.4.21:
+    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.2.0
+      nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+
+  /to-fast-properties/2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
+
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
     dev: true
 
-  /vue-demi/0.12.1_vue@3.2.29:
-    resolution: {integrity: sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==}
+  /vue-demi/0.13.11_vue@3.2.45:
+    resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
@@ -173,212 +190,14 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.2.29
+      vue: 3.2.45
     dev: false
 
-  /vue/3.2.29:
-    resolution: {integrity: sha512-cFIwr7LkbtCRanjNvh6r7wp2yUxfxeM2yPpDQpAfaaLIGZSrUmLbNiSze9nhBJt5MrZ68Iqt0O5scwAMEVxF+Q==}
+  /vue/3.2.45:
+    resolution: {integrity: sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==}
     dependencies:
-      '@vue/compiler-dom': 3.2.29
-      '@vue/compiler-sfc': 3.2.29
-      '@vue/runtime-dom': 3.2.29
-      '@vue/server-renderer': 3.2.29_vue@3.2.29
-      '@vue/shared': 3.2.29
-    dev: true
-
-  registry.npmjs.org/@socket.io/component-emitter/3.0.0:
-    resolution: {integrity: sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz}
-    name: '@socket.io/component-emitter'
-    version: 3.0.0
-    dev: true
-
-  registry.npmjs.org/@types/body-parser/1.19.2:
-    resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz}
-    name: '@types/body-parser'
-    version: 1.19.2
-    dependencies:
-      '@types/connect': registry.npmjs.org/@types/connect/3.4.35
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-    dev: true
-
-  registry.npmjs.org/@types/clone/2.1.1:
-    resolution: {integrity: sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz}
-    name: '@types/clone'
-    version: 2.1.1
-    dev: false
-
-  registry.npmjs.org/@types/connect/3.4.35:
-    resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz}
-    name: '@types/connect'
-    version: 3.4.35
-    dependencies:
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-    dev: true
-
-  registry.npmjs.org/@types/createjs-lib/0.0.29:
-    resolution: {integrity: sha1-+uguO6hgZmOxkOeJzsfZxyj8Qdc=, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/createjs-lib/-/createjs-lib-0.0.29.tgz}
-    name: '@types/createjs-lib'
-    version: 0.0.29
-    dev: true
-
-  registry.npmjs.org/@types/engine.io/3.1.7:
-    resolution: {integrity: sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz}
-    name: '@types/engine.io'
-    version: 3.1.7
-    dependencies:
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-    dev: true
-
-  registry.npmjs.org/@types/express-serve-static-core/4.17.28:
-    resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz}
-    name: '@types/express-serve-static-core'
-    version: 4.17.28
-    dependencies:
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-      '@types/qs': registry.npmjs.org/@types/qs/6.9.7
-      '@types/range-parser': registry.npmjs.org/@types/range-parser/1.2.4
-    dev: true
-
-  registry.npmjs.org/@types/express/4.17.13:
-    resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz}
-    name: '@types/express'
-    version: 4.17.13
-    dependencies:
-      '@types/body-parser': registry.npmjs.org/@types/body-parser/1.19.2
-      '@types/express-serve-static-core': registry.npmjs.org/@types/express-serve-static-core/4.17.28
-      '@types/qs': registry.npmjs.org/@types/qs/6.9.7
-      '@types/serve-static': registry.npmjs.org/@types/serve-static/1.13.10
-    dev: true
-
-  registry.npmjs.org/@types/mime/1.3.2:
-    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz}
-    name: '@types/mime'
-    version: 1.3.2
-    dev: true
-
-  registry.npmjs.org/@types/node/16.11.22:
-    resolution: {integrity: sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz}
-    name: '@types/node'
-    version: 16.11.22
-    dev: true
-
-  registry.npmjs.org/@types/preloadjs/0.6.32:
-    resolution: {integrity: sha1-Es/3x/kuODingNQ4zknIzsmBgw0=, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/preloadjs/-/preloadjs-0.6.32.tgz}
-    name: '@types/preloadjs'
-    version: 0.6.32
-    dependencies:
-      '@types/createjs-lib': registry.npmjs.org/@types/createjs-lib/0.0.29
-    dev: true
-
-  registry.npmjs.org/@types/qs/6.9.7:
-    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz}
-    name: '@types/qs'
-    version: 6.9.7
-    dev: true
-
-  registry.npmjs.org/@types/range-parser/1.2.4:
-    resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz}
-    name: '@types/range-parser'
-    version: 1.2.4
-    dev: true
-
-  registry.npmjs.org/@types/serve-static/1.13.10:
-    resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz}
-    name: '@types/serve-static'
-    version: 1.13.10
-    dependencies:
-      '@types/mime': registry.npmjs.org/@types/mime/1.3.2
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-    dev: true
-
-  registry.npmjs.org/@types/socket.io-client/1.4.36:
-    resolution: {integrity: sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz}
-    name: '@types/socket.io-client'
-    version: 1.4.36
-    dev: true
-
-  registry.npmjs.org/@types/socket.io-parser/3.0.0:
-    resolution: {integrity: sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz}
-    name: '@types/socket.io-parser'
-    version: 3.0.0
-    deprecated: This is a stub types definition. socket.io-parser provides its own type definitions, so you do not need this installed.
-    dependencies:
-      socket.io-parser: registry.npmjs.org/socket.io-parser/4.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  registry.npmjs.org/@types/socket.io/2.1.13:
-    resolution: {integrity: sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz}
-    name: '@types/socket.io'
-    version: 2.1.13
-    dependencies:
-      '@types/engine.io': registry.npmjs.org/@types/engine.io/3.1.7
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-      '@types/socket.io-parser': registry.npmjs.org/@types/socket.io-parser/3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  registry.npmjs.org/@types/soundjs/0.6.28:
-    resolution: {integrity: sha512-K3ktwPvYfQrH+qGEe1tgxC5o4rJC7CVxQmL9Cz9tgVq0oW99PmPfRp1F7YXELibCvV3lieD4E0sUZvnDEKWaPg==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/@types/soundjs/-/soundjs-0.6.28.tgz}
-    name: '@types/soundjs'
-    version: 0.6.28
-    dependencies:
-      '@types/createjs-lib': registry.npmjs.org/@types/createjs-lib/0.0.29
-      '@types/preloadjs': registry.npmjs.org/@types/preloadjs/0.6.32
-    dev: true
-
-  registry.npmjs.org/debug/4.3.3:
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/debug/-/debug-4.3.3.tgz}
-    name: debug
-    version: 4.3.3
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: registry.npmjs.org/ms/2.1.2
-    dev: true
-
-  registry.npmjs.org/ms/2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/ms/-/ms-2.1.2.tgz}
-    name: ms
-    version: 2.1.2
-    dev: true
-
-  registry.npmjs.org/nodecg-types/1.8.3:
-    resolution: {integrity: sha512-ZK5HsYjoX73XMsI5BboQSvquDWcjlUdG0gwqNbWuowVeJWCZ6KGAE2ZLL6o1hQ12YIlKLcqb/6Jju/y8CBghOw==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.3.tgz}
-    name: nodecg-types
-    version: 1.8.3
-    dependencies:
-      '@types/express': registry.npmjs.org/@types/express/4.17.13
-      '@types/node': registry.npmjs.org/@types/node/16.11.22
-      '@types/socket.io': registry.npmjs.org/@types/socket.io/2.1.13
-      '@types/socket.io-client': registry.npmjs.org/@types/socket.io-client/1.4.36
-      '@types/soundjs': registry.npmjs.org/@types/soundjs/0.6.28
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  registry.npmjs.org/socket.io-parser/4.1.1:
-    resolution: {integrity: sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.1.tgz}
-    name: socket.io-parser
-    version: 4.1.1
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@socket.io/component-emitter': registry.npmjs.org/@socket.io/component-emitter/3.0.0
-      debug: registry.npmjs.org/debug/4.3.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  registry.npmjs.org/typescript/4.5.5:
-    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz}
-    name: typescript
-    version: 4.5.5
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
+      '@vue/compiler-dom': 3.2.45
+      '@vue/compiler-sfc': 3.2.45
+      '@vue/runtime-dom': 3.2.45
+      '@vue/server-renderer': 3.2.45_vue@3.2.45
+      '@vue/shared': 3.2.45

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@alvancamp/test-nodecg-types': ^1.9.26
+  '@alvancamp/test-nodecg-types': ^1.9.27
   '@types/clone': ^2.1.1
   clone: ^2.1.2
   typescript: ^4.9.4
@@ -14,14 +14,14 @@ dependencies:
   vue-demi: 0.13.11_vue@3.2.45
 
 devDependencies:
-  '@alvancamp/test-nodecg-types': 1.9.26
+  '@alvancamp/test-nodecg-types': 1.9.27
   typescript: 4.9.4
   vue: 3.2.45
 
 packages:
 
-  /@alvancamp/test-nodecg-types/1.9.26:
-    resolution: {integrity: sha512-4Y1DuNHwLphwukyldS5KoCGo/taxPTngJAiKwhVhi6a2bokCNNGZ/g/4BSvFa8FqjlpU9+OH2MSX/hxz3HQpOA==}
+  /@alvancamp/test-nodecg-types/1.9.27:
+    resolution: {integrity: sha512-i1g7ob6Z9LC5NtEFRF/8F3NY1NvVPvum3O5gEAW2gUR9AhMSXVqdmLzF0c6GQgvQOdShovE6P0A5dybcuc2XJQ==}
     dev: true
 
   /@babel/helper-string-parser/7.19.4:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
         "target": "es2017",
         "module": "esnext",
         "lib": ["ESNext", "DOM", "DOM.Iterable"],
-        "types": ["@alvancamp/test-nodecg-types/augment-window"],
         "moduleResolution": "node",
         "esModuleInterop": true,
         "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,19 +8,8 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "strict": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
         "declaration": true,
-        "rootDir": ".",
-        "baseUrl": ".",
-        "skipLibCheck": true,
-        "skipDefaultLibCheck": true,
-        "noUnusedLocals": true,
-        "outDir": "./dist"
-      },
-
-    "exclude": [
-        "dist",
-        "node_modules"
-    ]
+        "outDir": "./dist",
+        "skipLibCheck": true
+    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "es2017",
         "module": "esnext",
         "lib": ["ESNext", "DOM", "DOM.Iterable"],
+        "types": ["@alvancamp/test-nodecg-types/augment-window"],
         "moduleResolution": "node",
         "esModuleInterop": true,
         "strict": true,


### PR DESCRIPTION
Not fully finished yet so keeping as a draft so I can discuss the issues.

- Bumped some dependencies and, in the process, updated `pnpm-lock.yaml` version to 5.4.
- Switched from `nodecg-types` library to `@alvancamp/test-nodecg-types`; in the future this will move to, IIRC, `@nodecg/types` but it will be a simple name swap.
- Added `import '@alvancamp/test-nodecg-types/augment-window'` which makes sure we get the correct `window` typings for the `nodecg` global; this could also be done in a few other ways but as this library only has 1 file I think this works OK.
- Swapped out the `ReplicantOptions` type to `NodeCG.Replicant.Options`; this type is slightly different but I think it's the correct substitute.

The current issues:
- ~~`NodeCG.Replicant.Options` has 2 sub-types, and one of them doesn't have `defaultValue`, so anywhere that references that will error. I think a simple "does it have this?" check would suffice, but I don't use the `defaultValue` setting on the browser side myself so wanted to check I wasn't missing anything.~~ Implemented a basic check, which should be good.
- ~~On line 94, we have `nodecg.Replicant(oldName).removeListener('change', repRef.value.listener)`, but `.removeListener` doesn't exist on the type for `nodecg.Replicant()`; if this is an error then we need to get it fixed in the type library.~~ Library issue, fixed.